### PR TITLE
Feature/alert to toast

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,9 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Header no longer depends on 'OrderFormContext' and no longer has Alert.
+
 ### Added
 - Add `linkUrl` prop to `Header` component that changes the logo link URL.
 

--- a/react/components/TopMenu.js
+++ b/react/components/TopMenu.js
@@ -25,7 +25,7 @@ class TopMenu extends Component {
   renderLogo(mobileMode, linkUrl, logoUrl, logoTitle) {
     return (
       <div className="vtex-top-menu__logo flex justify-start w-20-m w-25-l mw4 mw5-ns">
-        <Link to={linkurl} className="outline-0">
+        <Link to={linkUrl} className="outline-0">
           <ExtensionPoint
             id="logo"
             url={logoUrl}

--- a/react/index.js
+++ b/react/index.js
@@ -2,15 +2,8 @@ import React, { Component, Fragment } from 'react'
 import PropTypes from 'prop-types'
 import { injectIntl, intlShape } from 'react-intl'
 import hoistNonReactStatics from 'hoist-non-react-statics'
-import Modal from './components/Modal'
 import TopMenu from './components/TopMenu'
-import { Alert } from 'vtex.styleguide'
 import { ExtensionPoint, withRuntimeContext } from 'render'
-
-import {
-  orderFormConsumer,
-  contextPropTypes,
-} from 'vtex.store/OrderFormContext'
 
 import './global.css'
 
@@ -27,7 +20,6 @@ class Header extends Component {
     logoTitle: PropTypes.string,
     leanWhen: PropTypes.string,
     intl: intlShape.isRequired,
-    orderFormContext: contextPropTypes,
     showSearchBar: PropTypes.bool,
     showLogin: PropTypes.bool,
     runtime: PropTypes.shape({
@@ -79,14 +71,11 @@ class Header extends Component {
   }
 
   render() {
-    const { linkUrl, logoUrl, logoTitle, orderFormContext, showSearchBar, showLogin } = this.props
+    const { linkUrl, logoUrl, logoTitle, showSearchBar, showLogin } = this.props
     const { showMenuPopup } = this.state
 
     const leanMode = this.isLeanMode()
     const offsetTop = (this._root.current && this._root.current.offsetTop) || 0
-
-    const hasMessage =
-      orderFormContext.message.text && orderFormContext.message.text !== ''
 
     const topMenuOptions = {
       linkUrl,
@@ -116,17 +105,6 @@ class Header extends Component {
             className="flex flex-column items-center fixed w-100"
             style={{ top: offsetTop + 120 }}
           >
-            {hasMessage && (
-              <div className="pa2 mw9">
-                <Alert
-                  type={
-                    orderFormContext.message.isSuccess ? 'success' : 'error'
-                  }
-                >
-                  {orderFormContext.message.text}
-                </Alert>
-              </div>
-            )}
           </div>
         </div>
       </Fragment>
@@ -162,5 +140,5 @@ Header.schema = {
 }
 
 export default withRuntimeContext(
-  hoistNonReactStatics(orderFormConsumer(injectIntl(Header)), Header)
+  hoistNonReactStatics(injectIntl(Header), Header)
 )

--- a/react/index.js
+++ b/react/index.js
@@ -101,11 +101,6 @@ class Header extends Component {
           <div style={{ visibility: showMenuPopup ? 'inherit' : 'hidden' }}>
             <TopMenu fixed {...topMenuOptions} />
           </div>
-          <div
-            className="flex flex-column items-center fixed w-100"
-            style={{ top: offsetTop + 120 }}
-          >
-          </div>
         </div>
       </Fragment>
     )


### PR DESCRIPTION
#### What is the purpose of this pull request?

Removing Alert to use Toast. Header no longer depends on 'OrderFormContext'.

#### What problem is this solving?

Alert must be removed, and instead, use Toast.

#### How should this be manually tested?

[Access this workspace](https://orderby--storecomponents.myvtex.com/)

#### Types of changes
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
