### PR TITLE
Hide Search when user scrolls to top

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [2.4.3] - 2019-01-15
 ### Fixed
 - Hide mobile search when scrollled back to top and replace `Button` component with `ButtonWithIcon` component.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Hide mobile search when scrollled back to top and replace `Button` component with `ButtonWithIcon` component.
 
 ## [2.4.2] - 2019-01-14
 ### Fixed

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "store-header",
-  "version": "2.4.2",
+  "version": "2.4.3",
   "title": "VTEX Store Header",
   "defaultLocale": "pt-BR",
   "description": "The VTEX Store Header component",

--- a/react/components/TopMenu.js
+++ b/react/components/TopMenu.js
@@ -62,6 +62,8 @@ class TopMenu extends Component {
 
     const scrollValue = Math.min(1, scroll / Math.max(this.state.heightReduction, this.state.minHeight))
 
+    if(!scroll && this.state.mobileSearchActive)this.setState({mobileSearchActive: false})
+
     this.updateLogoScroll(scrollValue)
     this.updateTopBarScroll(scrollValue)
     this.updateSearchButtonScroll(scrollValue)

--- a/react/components/TopMenu.js
+++ b/react/components/TopMenu.js
@@ -4,7 +4,7 @@ import { FormattedMessage } from 'react-intl'
 import { ExtensionPoint } from 'render'
 import ResizeDetector from 'react-resize-detector'
 
-import { Button, IconSearch } from 'vtex.styleguide'
+import { ButtonWithIcon, IconSearch } from 'vtex.styleguide'
 import { Container } from 'vtex.store-components'
 
 import Logo from './Logo'
@@ -19,6 +19,7 @@ const LOGO_MAX_HEIGHT_DESKTOP = 75
 const LOGO_COLLAPSED_HEIGHT = 40
 const ICON_SIZE_MOBILE = 22
 const ICON_SIZE_DESKTOP = 30
+const MOBILE_SEARCH_SCROLL_LIMIT = 0.1979
 
 class TopMenu extends Component {
   container = React.createRef()
@@ -61,13 +62,18 @@ class TopMenu extends Component {
     if (typeof scroll !== 'number') return
 
     const scrollValue = Math.min(1, scroll / Math.max(this.state.heightReduction, this.state.minHeight))
-
-    if(!scroll && this.state.mobileSearchActive)this.setState({mobileSearchActive: false})
-
+    
+    this.updateMobileSearch(scrollValue)
     this.updateLogoScroll(scrollValue)
     this.updateTopBarScroll(scrollValue)
     this.updateSearchButtonScroll(scrollValue)
   }
+
+  updateMobileSearch = scrollValue => {
+    if(scrollValue <= MOBILE_SEARCH_SCROLL_LIMIT && this.state.mobileSearchActive){
+      this.setState({mobileSearchActive: false})
+    }
+  } 
 
   updateLogoScroll = scrollValue => {
     const logoElement = this.logoContainer.current
@@ -198,13 +204,12 @@ class TopMenu extends Component {
           <div className="flex dn-ns">
             {showSearchBar && !leanMode && (
               <div ref={this.mobileSearchButton} className="o-0">
-                <Button
-                  icon
+                <ButtonWithIcon
                   variation="tertiary"
                   onClick={() => this.setState(state => ({ mobileSearchActive: !state.mobileSearchActive }))}
                 >
                   <span className="c-muted-1"><IconSearch size={ICON_SIZE_MOBILE} /></span>
-                </Button>
+                </ButtonWithIcon>
               </div>
             )}
             {showLogin && (


### PR DESCRIPTION
#### What is the purpose of this pull request?
Hide the mobile search when user scrolls back to top.

#### What problem is this solving?
<!--- What is the motivation and context for this change? -->
The mobile search kept showing when the user scrolled back to top. When that happened, the two search bars were shown.
#### How should this be manually tested?
[workspace](https://hidetopbar--storecomponents.myvtex.com/)
#### Screenshots or example usage
*Before*
![storecomponents myvtex com_ galaxy s5 1](https://user-images.githubusercontent.com/4912690/51116193-31183680-17e9-11e9-893f-60ba029deed9.png)

*After*
![hidetopbar--storecomponents myvtex com_ galaxy s5](https://user-images.githubusercontent.com/4912690/51116211-3ffee900-17e9-11e9-8bcd-9984ab6e3b0a.png)



#### Types of changes
- [X] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
