### PR TITLE
Fix/align minicart items counter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [2.4.5] - 2019-01-17
 ### Fixed
 - Adjust alignment of the search button and fix the minicart item counter overlapping.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Adjust alignment of the search button and fix the minicart item counter overlapping.
 
 ## [2.4.4] - 2019-01-15
 ### Changed

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "store-header",
-  "version": "2.4.4",
+  "version": "2.4.5",
   "title": "VTEX Store Header",
   "defaultLocale": "pt-BR",
   "description": "The VTEX Store Header component",

--- a/react/components/TopMenu.js
+++ b/react/components/TopMenu.js
@@ -201,9 +201,9 @@ class TopMenu extends Component {
          **/}
         <ResizeDetector handleHeight onResize={this.handleUpdateIconsDimensions}>
           {/* Mobile icons */}
-          <div className="flex dn-ns">
+          <div className="flex dn-ns mr3">
             {showSearchBar && !leanMode && (
-              <div ref={this.mobileSearchButton} className="o-0">
+              <div ref={this.mobileSearchButton} className="o-0 pv2 nl5">
                 <ButtonWithIcon
                   variation="tertiary"
                   onClick={() => this.setState(state => ({ mobileSearchActive: !state.mobileSearchActive }))}


### PR DESCRIPTION
#### What is the purpose of this pull request?
Adjust the alignment of the minicart items counter in some iPhone devices such as iPhone4 and iPhone5. Besides, align the search icon.

#### What problem is this solving?
The overlapping counter of the minicart and the misalignment of the search icon.

#### How should this be manually tested?
Add some products to the minicart using iPhone4/5 and see the counter overlaps.

#### Screenshots or example usage
Before
![captura de tela de 2019-01-16 13-49-32](https://user-images.githubusercontent.com/9946330/51265593-e4269280-1997-11e9-8156-bcf1b861afa8.png)

After
![captura de tela de 2019-01-16 13-46-53](https://user-images.githubusercontent.com/9946330/51265577-dc66ee00-1997-11e9-9a44-ed2b0521beef.png)

[Workspace link](https://paddingminicartcounter--storecomponents.myvtex.com/)

#### Types of changes
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
