### PR TITLE
Hotfix/extra header bounce

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Prevent the size of the header bouncing across different pages.
 
 ## [2.6.1] - 2019-01-26
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [2.6.2] - 2019-01-28
 ### Fixed
 - Prevent the size of the header bouncing across different pages.
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "store-header",
-  "version": "2.6.1",
+  "version": "2.6.2",
   "title": "VTEX Store Header",
   "defaultLocale": "pt-BR",
   "description": "The VTEX Store Header component",

--- a/react/components/TopMenu.js
+++ b/react/components/TopMenu.js
@@ -312,7 +312,7 @@ class TopMenu extends Component {
         ...headerDimensions
       })
     } catch (error) {
-      // Unable to parse JSON. Skip.
+      // Unable to parse JSON. Skipping.
     }
   }
 
@@ -320,13 +320,17 @@ class TopMenu extends Component {
     const hasLocalStorage = window && window.localStorage
     if (!hasLocalStorage) return
 
-    localStorage.setItem('headerDimensions', JSON.stringify({
-      extraHeadersHeight: this.state.extraHeadersHeight,
-      minHeight: this.state.minHeight,
-      maxHeight: this.state.maxHeight,
-      logoHeight: this.state.logoHeight,
-      iconsHeight: this.state.iconsHeight,
-    }))
+    try {
+      localStorage.setItem('headerDimensions', JSON.stringify({
+        extraHeadersHeight: this.state.extraHeadersHeight,
+        minHeight: this.state.minHeight,
+        maxHeight: this.state.maxHeight,
+        logoHeight: this.state.logoHeight,
+        iconsHeight: this.state.iconsHeight,
+      }))
+    } catch (error) {
+      // Unable to save to localStorage. Skipping.
+    }
   }
 
   render() {

--- a/react/components/TopMenu.js
+++ b/react/components/TopMenu.js
@@ -42,7 +42,8 @@ class TopMenu extends Component {
 
     /** TODO: Use this `handleUpdateDimensions` instead of
      * `getInitialDimensions` when the problem mentioned in
-     * the declaration of the latter is fixed. */
+     * the declaration of the latter is fixed.
+     * @author lbebber */
     this.getInitialDimensions()
     this.handleScroll()
   }
@@ -296,8 +297,10 @@ class TopMenu extends Component {
 
   /** QUICK FIX - persist the calculated dimensions for the
    * first render to avoid bouncing.
-   * Caused by the header unmounting and re-mounting.
-   * TODO: Should be removed if/when that is fixed. */
+   * Caused by the header unmounting and re-mounting,
+   * and/or components being "forgotten" across page loads.
+   * TODO: Should be removed if/when that is fixed.
+   * @author lbebber */
   getInitialDimensions = () => {
     const hasLocalStorage = window && window.localStorage
     if (!hasLocalStorage) return
@@ -309,7 +312,7 @@ class TopMenu extends Component {
         ...headerDimensions
       })
     } catch (error) {
-      // Unable to parse JSON. Skip
+      // Unable to parse JSON. Skip.
     }
   }
 
@@ -350,8 +353,9 @@ class TopMenu extends Component {
             className={`w-100 mw9 flex justify-center ${leanMode ? 'pv0' : 'pv6-l pv2-m'}`}
             ref={this.content}
             style={{
-              // Prevents the empty margins of this element from blocking the users clicks
-              // TODO: create a tachyons class for pointer events and remove this style
+              /** Prevents the empty margins of this element from blocking the users clicks
+               * TODO: create a tachyons class for pointer events and remove this style
+               * @author lbebber */
               pointerEvents: 'none',
             }}
           >

--- a/react/components/TopMenu.js
+++ b/react/components/TopMenu.js
@@ -40,8 +40,11 @@ class TopMenu extends Component {
   componentDidMount() {
     document.addEventListener('scroll', this.handleScroll)
 
+    /** TODO: Use this `handleUpdateDimensions` instead of
+     * `getInitialDimensions` when the problem mentioned in
+     * the declaration of the latter is fixed. */
+    this.getInitialDimensions()
     this.handleScroll()
-    this.handleUpdateDimensions()
   }
 
   componentWillUnmount() {
@@ -152,6 +155,7 @@ class TopMenu extends Component {
       maxHeight,
       minHeight,
     }, () => {
+      this.saveInitialDimensions()
       this.props.onUpdateDimensions({ minHeight, maxHeight })
     })
   }
@@ -289,6 +293,34 @@ class TopMenu extends Component {
       )}
     </div>
   )
+
+  /** QUICK FIX - persist the calculated dimensions for the
+   * first render to avoid bouncing.
+   * Caused by the header unmounting and re-mounting.
+   * TODO: Should be removed if/when that is fixed. */
+  getInitialDimensions = () => {
+    const hasLocalStorage = window && window.localStorage
+    if (!hasLocalStorage) return
+
+    this.setState({
+      extraHeadersHeight: parseFloat(localStorage.getItem('extraHeadersHeight')),
+      minHeight: parseFloat(localStorage.getItem('minHeight')),
+      maxHeight: parseFloat(localStorage.getItem('maxHeight')),
+      logoHeight: parseFloat(localStorage.getItem('logoHeight')),
+      iconsHeight: parseFloat(localStorage.getItem('iconsHeight')),
+    })
+  }
+
+  saveInitialDimensions = () => {
+    const hasLocalStorage = window && window.localStorage
+    if (!hasLocalStorage) return
+
+    localStorage.setItem('extraHeadersHeight', this.state.extraHeadersHeight)
+    localStorage.setItem('minHeight', this.state.minHeight)
+    localStorage.setItem('maxHeight', this.state.maxHeight)
+    localStorage.setItem('logoHeight', this.state.logoHeight)
+    localStorage.setItem('iconsHeight', this.state.iconsHeight)
+  }
 
   render() {
     const { leanMode, extraHeaders } = this.props

--- a/react/components/TopMenu.js
+++ b/react/components/TopMenu.js
@@ -302,24 +302,28 @@ class TopMenu extends Component {
     const hasLocalStorage = window && window.localStorage
     if (!hasLocalStorage) return
 
-    this.setState({
-      extraHeadersHeight: parseFloat(localStorage.getItem('extraHeadersHeight')),
-      minHeight: parseFloat(localStorage.getItem('minHeight')),
-      maxHeight: parseFloat(localStorage.getItem('maxHeight')),
-      logoHeight: parseFloat(localStorage.getItem('logoHeight')),
-      iconsHeight: parseFloat(localStorage.getItem('iconsHeight')),
-    })
+    try {
+      const headerDimensions = JSON.parse(localStorage.getItem('headerDimensions'))
+
+      this.setState({
+        ...headerDimensions
+      })
+    } catch (error) {
+      // Unable to parse JSON. Skip
+    }
   }
 
   saveInitialDimensions = () => {
     const hasLocalStorage = window && window.localStorage
     if (!hasLocalStorage) return
 
-    localStorage.setItem('extraHeadersHeight', this.state.extraHeadersHeight)
-    localStorage.setItem('minHeight', this.state.minHeight)
-    localStorage.setItem('maxHeight', this.state.maxHeight)
-    localStorage.setItem('logoHeight', this.state.logoHeight)
-    localStorage.setItem('iconsHeight', this.state.iconsHeight)
+    localStorage.setItem('headerDimensions', JSON.stringify({
+      extraHeadersHeight: this.state.extraHeadersHeight,
+      minHeight: this.state.minHeight,
+      maxHeight: this.state.maxHeight,
+      logoHeight: this.state.logoHeight,
+      iconsHeight: this.state.iconsHeight,
+    }))
   }
 
   render() {


### PR DESCRIPTION
#### What is the purpose of this pull request?
Fixes repositioning and bouncing of the header components by persisting calculated dimensions across pages, in order to set during the initial render. 

After that, it is able to calculate them by itself and reposition in case of any change.

This is a quick fix, intended to be removed once/if the header is not unmounted and remounted every page load.

[Try it here](https://lbebber4--storecomponents.myvtex.com/)

#### Types of changes
- [X] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
