### PR TITLE
Fix header bouncing on resizing and icons style

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Fix header bouncing and change icons style.
 
 ## [2.7.0] - 2019-01-30
 ### Changed

--- a/react/components/SearchBar.js
+++ b/react/components/SearchBar.js
@@ -25,6 +25,7 @@ const SearchBar = ({ compactMode, autoFocus, onCancel }) => {
                 emptyPlaceholder={emptyPlaceholder}
                 compactMode={compactMode}
                 autoFocus={autoFocus}
+                iconClasses="c-on-base"
               />
             )}
           </Adopt>

--- a/react/components/SearchBar.js
+++ b/react/components/SearchBar.js
@@ -25,7 +25,7 @@ const SearchBar = ({ compactMode, autoFocus, onCancel }) => {
                 emptyPlaceholder={emptyPlaceholder}
                 compactMode={compactMode}
                 autoFocus={autoFocus}
-                iconClasses="c-on-base"
+                iconClasses="c-muted-1"
               />
             )}
           </Adopt>

--- a/react/components/TopMenu.js
+++ b/react/components/TopMenu.js
@@ -221,15 +221,15 @@ class TopMenu extends Component {
             {showLogin && (
               <ExtensionPoint
                 id="login"
-                iconClasses="c-on-base"
-                labelClasses="c-on-base"
+                iconClasses="c-muted-1"
+                labelClasses="c-muted-1"
                 iconSize={ICON_SIZE_MOBILE}
               />
             )}
             {!leanMode && <ExtensionPoint
               id="minicart"
-              iconClasses="c-on-base"
-              labelClasses="c-on-base"
+              iconClasses="c-muted-1"
+              labelClasses="c-muted-1"
               iconSize={ICON_SIZE_MOBILE}
             />}
           </div>
@@ -238,8 +238,8 @@ class TopMenu extends Component {
             {showLogin && (
               <ExtensionPoint
                 id="login"
-                iconClasses="c-on-base"
-                labelClasses="c-on-base"
+                iconClasses="c-muted-1"
+                labelClasses="c-muted-1"
                 iconSize={ICON_SIZE_DESKTOP}
                 iconLabel={<FormattedMessage id="header.topMenu.login.icon.label" />}
               />
@@ -247,8 +247,8 @@ class TopMenu extends Component {
             {!leanMode && (
               <ExtensionPoint
                 id="minicart"
-                iconClasses="c-on-base"
-                labelClasses="c-on-base"
+                iconClasses="c-muted-1"
+                labelClasses="c-muted-1"
                 iconSize={ICON_SIZE_DESKTOP}
                 iconLabel={<FormattedMessage id="header.topMenu.minicart.icon.label" />}
               />
@@ -355,7 +355,7 @@ class TopMenu extends Component {
           }}
         >
           <div
-            className={`w-100 mw9 flex justify-center ${leanMode ? 'pv0' : 'pv2'}`}
+            className={`w-100 mw9 flex justify-center ${leanMode ? 'pv0' : 'pv1'}`}
             ref={this.content}
             style={{
               /** Prevents the empty margins of this element from blocking the users clicks

--- a/react/components/TopMenu.js
+++ b/react/components/TopMenu.js
@@ -18,7 +18,7 @@ const LOGO_MAX_HEIGHT_DESKTOP = 60
 const LOGO_MAX_WIDTH_MOBILE = 90
 const LOGO_MAX_HEIGHT_MOBILE = 40
 const LOGO_COLLAPSED_HEIGHT = 40
-const ICON_SIZE_MOBILE = 22
+const ICON_SIZE_MOBILE = 16
 const ICON_SIZE_DESKTOP = 16
 const MOBILE_SEARCH_SCROLL_LIMIT = 0.1979
 
@@ -365,7 +365,7 @@ class TopMenu extends Component {
             }}
           >
             <div
-              className="flex w-100 justify-between-m items-center pv3"
+              className="flex w-100 justify-between-m items-center pv2"
               style={{
                 pointerEvents: 'auto',
               }}>

--- a/react/components/TopMenu.js
+++ b/react/components/TopMenu.js
@@ -13,13 +13,13 @@ import SearchBar from './SearchBar'
 
 import header from '../store-header.css'
 
-const LOGO_MAX_WIDTH_DESKTOP = 150
+const LOGO_MAX_WIDTH_DESKTOP = 146
+const LOGO_MAX_HEIGHT_DESKTOP = 52
 const LOGO_MAX_WIDTH_MOBILE = 90
 const LOGO_MAX_HEIGHT_MOBILE = 40
-const LOGO_MAX_HEIGHT_DESKTOP = 75
 const LOGO_COLLAPSED_HEIGHT = 40
 const ICON_SIZE_MOBILE = 22
-const ICON_SIZE_DESKTOP = 30
+const ICON_SIZE_DESKTOP = 16
 const MOBILE_SEARCH_SCROLL_LIMIT = 0.1979
 
 class TopMenu extends Component {
@@ -221,15 +221,15 @@ class TopMenu extends Component {
             {showLogin && (
               <ExtensionPoint
                 id="login"
-                iconClasses="c-muted-1"
-                labelClasses="c-muted-1"
+                iconClasses="c-on-base"
+                labelClasses="c-on-base"
                 iconSize={ICON_SIZE_MOBILE}
               />
             )}
             {!leanMode && <ExtensionPoint
               id="minicart"
-              iconClasses="c-muted-1"
-              labelClasses="c-muted-1"
+              iconClasses="c-on-base"
+              labelClasses="c-on-base"
               iconSize={ICON_SIZE_MOBILE}
             />}
           </div>
@@ -238,8 +238,8 @@ class TopMenu extends Component {
             {showLogin && (
               <ExtensionPoint
                 id="login"
-                iconClasses="c-muted-1"
-                labelClasses="c-muted-1"
+                iconClasses="c-on-base"
+                labelClasses="c-on-base"
                 iconSize={ICON_SIZE_DESKTOP}
                 iconLabel={<FormattedMessage id="header.topMenu.login.icon.label" />}
               />
@@ -247,8 +247,8 @@ class TopMenu extends Component {
             {!leanMode && (
               <ExtensionPoint
                 id="minicart"
-                iconClasses="c-muted-1"
-                labelClasses="c-muted-1"
+                iconClasses="c-on-base"
+                labelClasses="c-on-base"
                 iconSize={ICON_SIZE_DESKTOP}
                 iconLabel={<FormattedMessage id="header.topMenu.minicart.icon.label" />}
               />
@@ -355,7 +355,7 @@ class TopMenu extends Component {
           }}
         >
           <div
-            className={`w-100 mw9 flex justify-center ${leanMode ? 'pv0' : 'pv6-l pv2-m'}`}
+            className={`w-100 mw9 flex justify-center ${leanMode ? 'pv0' : 'pv2'}`}
             ref={this.content}
             style={{
               /** Prevents the empty margins of this element from blocking the users clicks

--- a/react/components/TopMenu.js
+++ b/react/components/TopMenu.js
@@ -14,7 +14,7 @@ import SearchBar from './SearchBar'
 import header from '../store-header.css'
 
 const LOGO_MAX_WIDTH_DESKTOP = 146
-const LOGO_MAX_HEIGHT_DESKTOP = 52
+const LOGO_MAX_HEIGHT_DESKTOP = 60
 const LOGO_MAX_WIDTH_MOBILE = 90
 const LOGO_MAX_HEIGHT_MOBILE = 40
 const LOGO_COLLAPSED_HEIGHT = 40


### PR DESCRIPTION
#### What is the purpose of this pull request? #### What problem is this solving?
Fix header height bouncing when change screen resolution on desktop and icons style.

#### How should this be manually tested?
https://headerbouncing--storecomponents.myvtex.com/

#### Types of changes
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
