### PR TITLE
Use runtime to render the different minicart extension points

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Use `runtime` to render the different minicart extension points.
 
 ## [2.7.2] - 2019-02-09
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,10 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 
+## [2.7.2] - 2019-02-09
+### Fixed
+- Back with `menu-link` block.
+
 ## [2.7.1] - 2019-02-01
 
 ## [2.7.0] - 2019-01-30

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "store-header",
-  "version": "2.7.1",
+  "version": "2.7.2",
   "title": "VTEX Store Header",
   "defaultLocale": "pt-BR",
   "description": "The VTEX Store Header component",

--- a/react/components/TopMenu.js
+++ b/react/components/TopMenu.js
@@ -1,7 +1,7 @@
 import React, { Component } from 'react'
 import PropTypes from 'prop-types'
 import { FormattedMessage } from 'react-intl'
-import { ExtensionPoint } from 'vtex.render-runtime'
+import { ExtensionPoint, withRuntimeContext } from 'vtex.render-runtime'
 import ResizeDetector from 'react-resize-detector'
 
 import { ButtonWithIcon } from 'vtex.styleguide'
@@ -66,7 +66,10 @@ class TopMenu extends Component {
 
     if (typeof scroll !== 'number') return
 
-    const scrollValue = Math.min(1, scroll / Math.max(this.state.heightReduction, this.state.minHeight))
+    const scrollValue = Math.min(
+      1,
+      scroll / Math.max(this.state.heightReduction, this.state.minHeight)
+    )
 
     this.updateMobileSearch(scrollValue)
     this.updateLogoScroll(scrollValue)
@@ -75,7 +78,10 @@ class TopMenu extends Component {
   }
 
   updateMobileSearch = scrollValue => {
-    if (scrollValue <= MOBILE_SEARCH_SCROLL_LIMIT && this.state.mobileSearchActive) {
+    if (
+      scrollValue <= MOBILE_SEARCH_SCROLL_LIMIT &&
+      this.state.mobileSearchActive
+    ) {
       this.setState({ mobileSearchActive: false })
     }
   }
@@ -83,8 +89,11 @@ class TopMenu extends Component {
   updateLogoScroll = scrollValue => {
     const logoElement = this.logoContainer.current
     if (logoElement) {
-      const targetScale = Math.min(1, LOGO_COLLAPSED_HEIGHT / this.state.logoHeight)
-      const scale = 1 - (scrollValue * (1 - targetScale))
+      const targetScale = Math.min(
+        1,
+        LOGO_COLLAPSED_HEIGHT / this.state.logoHeight
+      )
+      const scale = 1 - scrollValue * (1 - targetScale)
       logoElement.style.transform = `scale(${scale})`
     }
   }
@@ -94,12 +103,13 @@ class TopMenu extends Component {
    * position and the position of its contents. This is done for performance
    * (changing height triggers a reflow, which is expensive. Setting transform
    * only triggers a composition, which is cheap)
-  **/
+   **/
   updateTopBarScroll = scrollValue => {
     // This division/rounding/multiplication prevents the position from being a non-integer
     // on either elements, so as to not to become blurry on non-retina displays, and makes both
     // move in tandem, preventing "jumpiness"
-    const currentHeightReduction = Math.round((scrollValue * this.state.heightReduction) / 2) * 2
+    const currentHeightReduction =
+      Math.round((scrollValue * this.state.heightReduction) / 2) * 2
 
     const containerElement = this.container.current
     if (containerElement) {
@@ -124,57 +134,86 @@ class TopMenu extends Component {
   getContentPaddings = () => {
     // Gets the calculated vertical paddings of the content container
     const contentElement = this.content.current
-    const contentComputedStyles = contentElement && window.getComputedStyle && window.getComputedStyle(contentElement, null)
-    return contentComputedStyles ? parseFloat(contentComputedStyles.getPropertyValue('padding-top')) * 2 : 0
+    const contentComputedStyles =
+      contentElement &&
+      window.getComputedStyle &&
+      window.getComputedStyle(contentElement, null)
+    return contentComputedStyles
+      ? parseFloat(contentComputedStyles.getPropertyValue('padding-top')) * 2
+      : 0
   }
 
   handleUpdateIconsDimensions = (width, height) => {
-    this.setState({
-      iconsHeight: height,
-    }, () => {
-      this.handleUpdateDimensions()
-    })
+    this.setState(
+      {
+        iconsHeight: height,
+      },
+      () => {
+        this.handleUpdateDimensions()
+      }
+    )
   }
 
   handleUpdateLogoDimensions = (width, height) => {
-    this.setState({
-      logoHeight: height,
-    }, () => {
-      this.handleUpdateDimensions()
-    })
+    this.setState(
+      {
+        logoHeight: height,
+      },
+      () => {
+        this.handleUpdateDimensions()
+      }
+    )
   }
 
   handleUpdateDimensions = () => {
     const contentPaddings = this.getContentPaddings()
-    const logoReduction = Math.max(0, this.state.logoHeight - Math.max(this.state.iconsHeight, LOGO_COLLAPSED_HEIGHT))
+    const logoReduction = Math.max(
+      0,
+      this.state.logoHeight -
+        Math.max(this.state.iconsHeight, LOGO_COLLAPSED_HEIGHT)
+    )
     const heightReduction = Math.max(0, contentPaddings + logoReduction)
 
-    const maxHeight = (this.container.current ? this.container.current.offsetHeight : 0) + this.state.extraHeadersHeight
+    const maxHeight =
+      (this.container.current ? this.container.current.offsetHeight : 0) +
+      this.state.extraHeadersHeight
     const minHeight = maxHeight - heightReduction - (heightReduction % 2)
 
-    this.setState({
-      heightReduction,
-      maxHeight,
-      minHeight,
-    }, () => {
-      this.saveInitialDimensions()
-      this.props.onUpdateDimensions({ minHeight, maxHeight })
-    })
+    this.setState(
+      {
+        heightReduction,
+        maxHeight,
+        minHeight,
+      },
+      () => {
+        this.saveInitialDimensions()
+        this.props.onUpdateDimensions({ minHeight, maxHeight })
+      }
+    )
   }
 
   handleExtraHeadersResize = (width, height) => {
-    this.setState({
-      extraHeadersHeight: height,
-    }, () => {
-      this.handleUpdateDimensions()
-    })
+    this.setState(
+      {
+        extraHeadersHeight: height,
+      },
+      () => {
+        this.handleUpdateDimensions()
+      }
+    )
   }
 
   renderLogo = () => {
     const { logoUrl, linkUrl, logoTitle, leanMode } = this.props
 
-    const sizeDesktop = { width: LOGO_MAX_WIDTH_DESKTOP, height: LOGO_MAX_HEIGHT_DESKTOP }
-    const sizeMobile = { width: LOGO_MAX_WIDTH_MOBILE, height: LOGO_MAX_HEIGHT_MOBILE }
+    const sizeDesktop = {
+      width: LOGO_MAX_WIDTH_DESKTOP,
+      height: LOGO_MAX_HEIGHT_DESKTOP,
+    }
+    const sizeMobile = {
+      width: LOGO_MAX_WIDTH_MOBILE,
+      height: LOGO_MAX_HEIGHT_MOBILE,
+    }
 
     return (
       <div className="mr5" ref={this.logoContainer}>
@@ -197,63 +236,90 @@ class TopMenu extends Component {
   )
 
   renderIcons() {
-    const { leanMode, showLogin, showSearchBar } = this.props
+    const {
+      leanMode,
+      showLogin,
+      showSearchBar,
+      runtime: {
+        hints: { mobile },
+      },
+    } = this.props
 
     return (
-      <div className={`${header.topMenuIcons} flex justify-end flex-grow-1 flex-grow-0-ns items-center order-1-s ml-auto-s order-2-ns`}>
+      <div
+        className={`${
+          header.topMenuIcons
+        } flex justify-end flex-grow-1 flex-grow-0-ns items-center order-1-s ml-auto-s order-2-ns`}
+      >
         {/**
-          * Both desktop and mobile icons are rendered, and hidden through CSS,
-          * for better server side rendering support
+         * Both desktop and mobile icons are rendered, and hidden through CSS,
+         * for better server side rendering support
          **/}
-        <ResizeDetector handleHeight onResize={this.handleUpdateIconsDimensions}>
-          {/* Mobile icons */}
-          <div className="flex dn-ns mr3">
-            {showSearchBar && !leanMode && (
-              <div ref={this.mobileSearchButton} className="o-0 pv2 nl5">
-                <ButtonWithIcon
-                  variation="tertiary"
-                  onClick={() => this.setState(state => ({ mobileSearchActive: !state.mobileSearchActive }))}
-                >
-                  <IconSearch size={ICON_SIZE_MOBILE} className="c-muted-1" />
-                </ButtonWithIcon>
-              </div>
-            )}
-            {showLogin && (
-              <ExtensionPoint
-                id="login"
-                iconClasses="c-muted-1"
-                labelClasses="c-muted-1"
-                iconSize={ICON_SIZE_MOBILE}
-              />
-            )}
-            {!leanMode && <ExtensionPoint
-              id="minicart"
-              iconClasses="c-muted-1"
-              labelClasses="c-muted-1"
-              iconSize={ICON_SIZE_MOBILE}
-            />}
-          </div>
-          {/** Desktop icons */}
-          <div className="dn flex-ns">
-            {showLogin && (
-              <ExtensionPoint
-                id="login"
-                iconClasses="c-muted-1"
-                labelClasses="c-muted-1"
-                iconSize={ICON_SIZE_DESKTOP}
-                iconLabel={<FormattedMessage id="header.topMenu.login.icon.label" />}
-              />
-            )}
-            {!leanMode && (
-              <ExtensionPoint
-                id="minicart"
-                iconClasses="c-muted-1"
-                labelClasses="c-muted-1"
-                iconSize={ICON_SIZE_DESKTOP}
-                iconLabel={<FormattedMessage id="header.topMenu.minicart.icon.label" />}
-              />
-            )}
-          </div>
+        <ResizeDetector
+          handleHeight
+          onResize={this.handleUpdateIconsDimensions}
+        >
+          {mobile ? (
+            /* Mobile icons */
+            <div className="flex mr3">
+              {showSearchBar && !leanMode && (
+                <div ref={this.mobileSearchButton} className="o-0 pv2 nl5">
+                  <ButtonWithIcon
+                    variation="tertiary"
+                    onClick={() =>
+                      this.setState(state => ({
+                        mobileSearchActive: !state.mobileSearchActive,
+                      }))
+                    }
+                  >
+                    <IconSearch size={ICON_SIZE_MOBILE} className="c-muted-1" />
+                  </ButtonWithIcon>
+                </div>
+              )}
+              {showLogin && (
+                <ExtensionPoint
+                  id="login"
+                  iconClasses="c-muted-1"
+                  labelClasses="c-muted-1"
+                  iconSize={ICON_SIZE_MOBILE}
+                />
+              )}
+              {!leanMode && (
+                <ExtensionPoint
+                  id="minicart"
+                  iconClasses="c-muted-1"
+                  labelClasses="c-muted-1"
+                  iconSize={ICON_SIZE_MOBILE}
+                />
+              )}
+            </div>
+          ) : (
+            /** Desktop icons */
+            <div className="dn flex-ns">
+              {showLogin && (
+                <ExtensionPoint
+                  id="login"
+                  iconClasses="c-muted-1"
+                  labelClasses="c-muted-1"
+                  iconSize={ICON_SIZE_DESKTOP}
+                  iconLabel={
+                    <FormattedMessage id="header.topMenu.login.icon.label" />
+                  }
+                />
+              )}
+              {!leanMode && (
+                <ExtensionPoint
+                  id="minicart"
+                  iconClasses="c-muted-1"
+                  labelClasses="c-muted-1"
+                  iconSize={ICON_SIZE_DESKTOP}
+                  iconLabel={
+                    <FormattedMessage id="header.topMenu.minicart.icon.label" />
+                  }
+                />
+              )}
+            </div>
+          )}
         </ResizeDetector>
       </div>
     )
@@ -272,17 +338,17 @@ class TopMenu extends Component {
         />
       </div>
     ) : (
-        <React.Fragment>
-          {!leanMode && this.renderMobileCategoryMenu()}
-          {this.renderLogo()}
-          {!leanMode && (
-            <div className="dn db-ns flex-grow-1">
-              <SearchBar />
-            </div>
-          )}
-          {this.renderIcons()}
-        </React.Fragment>
-      )
+      <React.Fragment>
+        {!leanMode && this.renderMobileCategoryMenu()}
+        {this.renderLogo()}
+        {!leanMode && (
+          <div className="dn db-ns flex-grow-1">
+            <SearchBar />
+          </div>
+        )}
+        {this.renderIcons()}
+      </React.Fragment>
+    )
   }
 
   renderCollapsibleContent = () => (
@@ -307,10 +373,12 @@ class TopMenu extends Component {
     if (!hasLocalStorage) return
 
     try {
-      const headerDimensions = JSON.parse(localStorage.getItem('headerDimensions'))
+      const headerDimensions = JSON.parse(
+        localStorage.getItem('headerDimensions')
+      )
 
       this.setState({
-        ...headerDimensions
+        ...headerDimensions,
       })
     } catch (error) {
       // Unable to parse JSON. Skipping.
@@ -322,13 +390,16 @@ class TopMenu extends Component {
     if (!hasLocalStorage) return
 
     try {
-      localStorage.setItem('headerDimensions', JSON.stringify({
-        extraHeadersHeight: this.state.extraHeadersHeight,
-        minHeight: this.state.minHeight,
-        maxHeight: this.state.maxHeight,
-        logoHeight: this.state.logoHeight,
-        iconsHeight: this.state.iconsHeight,
-      }))
+      localStorage.setItem(
+        'headerDimensions',
+        JSON.stringify({
+          extraHeadersHeight: this.state.extraHeadersHeight,
+          minHeight: this.state.minHeight,
+          maxHeight: this.state.maxHeight,
+          logoHeight: this.state.logoHeight,
+          iconsHeight: this.state.iconsHeight,
+        })
+      )
     } catch (error) {
       // Unable to save to localStorage. Skipping.
     }
@@ -348,14 +419,20 @@ class TopMenu extends Component {
           </ResizeDetector>
         </div>
         <Container
-          className={`${header.topMenuContainer} flex justify-center w-100 bg-base left-0 z-3 ${hasCalculatedMenuHeight ? 'fixed' : 'relative'}`}
+          className={`${
+            header.topMenuContainer
+          } flex justify-center w-100 bg-base left-0 z-3 ${
+            hasCalculatedMenuHeight ? 'fixed' : 'relative'
+          }`}
           ref={this.container}
           style={{
             top: extraHeadersHeight,
           }}
         >
           <div
-            className={`w-100 mw9 flex justify-center ${leanMode ? 'pv0' : 'pv6-l pv2-m'}`}
+            className={`w-100 mw9 flex justify-center ${
+              leanMode ? 'pv0' : 'pv6-l pv2-m'
+            }`}
             ref={this.content}
             style={{
               /** Prevents the empty margins of this element from blocking the users clicks
@@ -368,7 +445,8 @@ class TopMenu extends Component {
               className="flex w-100 justify-between-m items-center pv3"
               style={{
                 pointerEvents: 'auto',
-              }}>
+              }}
+            >
               {this.renderFixedContent()}
             </div>
           </div>
@@ -415,12 +493,13 @@ TopMenu.propTypes = {
   leanMode: PropTypes.bool,
   onUpdateDimensions: PropTypes.func,
   extraHeaders: PropTypes.node,
+  runtime: PropTypes.object.isRequired,
 }
 
 TopMenu.defaultProps = {
   showSearchBar: true,
   showLogin: true,
-  onUpdateDimensions: () => { },
+  onUpdateDimensions: () => {},
 }
 
-export default TopMenu
+export default withRuntimeContext(TopMenu)

--- a/react/index.js
+++ b/react/index.js
@@ -1,4 +1,4 @@
-import React, { Component } from 'react'
+import React, { Component, Fragment } from 'react'
 import PropTypes from 'prop-types'
 import { ExtensionPoint, withRuntimeContext } from 'vtex.render-runtime'
 
@@ -62,11 +62,12 @@ class Header extends Component {
           {...topMenuOptions}
           leanMode={leanMode}
           extraHeaders={(
-            <ExtensionPoint id="telemarketing" />
-            // TODO: either add support or remove menu-link
-            // <div className="z-2 items-center w-100 top-0 bg-base tl">
-            //   <ExtensionPoint id="menu-link" />
-            // </div>
+            <Fragment>
+              <ExtensionPoint id="telemarketing" />
+              <div className="z-2 items-center w-100 top-0 bg-base tl">
+                <ExtensionPoint id="menu-link" />
+              </div>
+            </Fragment>
           )}
         />
       </div>

--- a/store/blocks.json
+++ b/store/blocks.json
@@ -8,6 +8,7 @@
   "header.full": {
     "blocks": [
       "telemarketing",
+      "menu-link",
       "logo",
       "minicart",
       "login",

--- a/store/interfaces.json
+++ b/store/interfaces.json
@@ -15,10 +15,6 @@
     "component": "index"
   },
   "header.full": {
-    "allowed": [
-      "menu-link",
-      "theme"
-    ],
     "required": [
       "telemarketing",
       "logo",


### PR DESCRIPTION
#### What is the purpose of this pull request?

The minicart extension points cannot use the media queries to show or not. This way, we'll have two minicarts instead of one.

#### What problem is this solving?

Two minicarts instead of one.

#### How should this be manually tested?

[Access the workspace](https://offline--storecomponents.myvtex.com/) in mobile mode

#### Screenshots or example usage

![image](https://user-images.githubusercontent.com/15948386/52587171-397b8580-2e18-11e9-9efc-2b2f7ec09156.png)

#### Types of changes
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
