### PR TITLE
Fix Spacer height

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- `Header` now queries DOM for its container size and pass it to `Spacer`.
 
 ## [2.10.4] - 2019-03-14
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [2.10.5] - 2019-03-14
 ### Fixed
 - `Header` now queries DOM for its container size and pass it to `Spacer`.
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "store-header",
-  "version": "2.10.4",
+  "version": "2.10.5",
   "title": "VTEX Store Header",
   "defaultLocale": "pt-BR",
   "description": "The VTEX Store Header component",

--- a/react/components/Helpers/Spacer.js
+++ b/react/components/Helpers/Spacer.js
@@ -8,7 +8,7 @@ import useDevice from '../../hooks/useDevice'
 const Spacer = ({ spacerHeightDesktop, spacerHeightMobile, spacerWidth, containerHeight }) => {
   const { desktop } = useDevice()
 
-  let height = containerHeight || (desktop ? spacerHeightDesktop : spacerHeightMobile)
+  const height = containerHeight || (desktop ? spacerHeightDesktop : spacerHeightMobile)
 
   return (
     <div

--- a/react/components/Helpers/Spacer.js
+++ b/react/components/Helpers/Spacer.js
@@ -5,14 +5,16 @@ import useDevice from '../../hooks/useDevice'
 /**
  * Spacer necessary to content due fixed Header
  */
-const Spacer = ({ spacerHeightDesktop, spacerHeightMobile, spacerWidth }) => {
+const Spacer = ({ spacerHeightDesktop, spacerHeightMobile, spacerWidth, containerHeight }) => {
   const { desktop } = useDevice()
+
+  let height = containerHeight || (desktop ? spacerHeightDesktop : spacerHeightMobile)
 
   return (
     <div
       className="z-1 bg-base w-100 relative"
       style={{
-        height: desktop ? spacerHeightDesktop : spacerHeightMobile,
+        height,
         width: spacerWidth,
       }}
     />

--- a/react/index.js
+++ b/react/index.js
@@ -1,4 +1,4 @@
-import React, { Fragment } from 'react'
+import React, { Fragment, useEffect, useLayoutEffect, useState } from 'react'
 import classNames from 'classnames'
 import PropTypes from 'prop-types'
 import { ExtensionPoint, useRuntime } from 'vtex.render-runtime'
@@ -26,6 +26,15 @@ const Header = ({
 }) => {
   const { page } = useRuntime()
   const { mobile } = useDevice()
+  const [containerHeight, setContainerHeight] = useState(null)
+
+  useEffect(() => {
+    if (document) {
+      const containerElement = document.getElementsByClassName('vtex-store-header-2-x-container')[0]
+      const elementHeight = containerElement && containerElement.offsetHeight
+      setContainerHeight(elementHeight)
+    }
+  })
 
   const topMenuOptions = {
     linkUrl,
@@ -70,7 +79,7 @@ const Header = ({
           }
         />
       </div>
-      <Spacer />
+      <Spacer containerHeight={containerHeight} />
     </Fragment>
   )
 }

--- a/react/index.js
+++ b/react/index.js
@@ -30,7 +30,7 @@ const Header = ({
 
   useEffect(() => {
     if (document) {
-      const containerElement = document.getElementsByClassName('vtex-store-header-2-x-container')[0]
+      const containerElement = document.querySelector('.vtex-store-header-2-x-container')
       const elementHeight = containerElement && containerElement.offsetHeight
       setContainerHeight(elementHeight)
     }

--- a/react/package.json
+++ b/react/package.json
@@ -24,5 +24,8 @@
   "devDependencies": {
     "@vtex/test-tools": "^0.1.2",
     "apollo-client": "^2.5.1"
+  },
+  "vtexTestTools": {
+    "defaultLocale": "en"
   }
 }


### PR DESCRIPTION
#### What problem is this solving?
Fix header spacing.

#### Screenshots or example usage
![Screen Shot 2019-03-14 at 14 27 38](https://user-images.githubusercontent.com/10400340/54378117-5993a400-4665-11e9-85d6-c5b82b9164af.png)


#### Types of changes
- [x] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.

### Notes
I tried these two approaches:

1. Using the `useRef` hook to get the container `ref`.
2. `document.getElementsByClassName`.

The first solution was considerably slower than the second.. Suggestions are welcome 😄 
