### PR TITLE
Fixes FixedContent background being limited by Container width

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+
+## [2.12.2] - 2019-04-11
 ### Fixed
 - Fixed bug where the width of the FixedContent part of the Legacy header would be limited by the Container's width.
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Fixed bug where the width of the FixedContent part of the Legacy header would be limited by the Containe width.
 
 ## [2.12.1] - 2019-04-10
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 ### Fixed
-- Fixed bug where the width of the FixedContent part of the Legacy header would be limited by the Containe width.
+- Fixed bug where the width of the FixedContent part of the Legacy header would be limited by the Container's width.
 
 ## [2.12.1] - 2019-04-10
 

--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "vendor": "vtex",
   "name": "store-header",
-  "version": "2.12.1",
+  "version": "2.12.2",
   "title": "VTEX Store Header",
   "defaultLocale": "pt-BR",
   "description": "The VTEX Store Header component",

--- a/react/__tests__/__snapshots__/Header.test.js.snap
+++ b/react/__tests__/__snapshots__/Header.test.js.snap
@@ -20,51 +20,55 @@ exports[`Header Component should match snapshot mobile with leanmode 1`] = `
         menu-link
       </div>
     </div>
-    <section
-      class="container-mock"
+    <div
+      class="w-100 bg-base"
     >
-      <div
-        class="w-100 mw9 flex justify-center pv0"
-        style="pointer-events: none;"
+      <section
+        class="container-mock"
       >
         <div
-          class="flex w-100 justify-between-m items-center pv3"
-          style="pointer-events: auto;"
+          class="w-100 mw9 flex justify-center pv0"
+          style="pointer-events: none;"
         >
           <div
-            class="topMenuLogo pv2 mr5"
+            class="flex w-100 justify-between-m items-center pv3"
+            style="pointer-events: auto;"
           >
             <div
-              class="link-mock"
+              class="topMenuLogo pv2 mr5"
             >
               <div
-                class="extension-point-mock"
+                class="link-mock"
               >
-                logo
+                <div
+                  class="extension-point-mock"
+                >
+                  logo
+                </div>
               </div>
             </div>
-          </div>
-          <div
-            class="topMenuIcons flex justify-end flex-grow-1 flex-grow-0-ns items-center order-1-s ml-auto-s order-2-ns"
-          >
             <div
-              class="flex"
+              class="topMenuIcons flex justify-end flex-grow-1 flex-grow-0-ns items-center order-1-s ml-auto-s order-2-ns"
             >
               <div
-                class="extension-point-mock"
+                class="flex"
               >
-                login
+                <div
+                  class="extension-point-mock"
+                >
+                  login
+                </div>
               </div>
             </div>
-          </div>
-          <div
-            class="extension-point-mock"
-          >
-            user-address
+            <div
+              class="extension-point-mock"
+            >
+              user-address
+            </div>
           </div>
         </div>
-      </div>
-    </section>
+      </section>
+    </div>
     <div
       class="bb bw1 b--muted-4 relative"
       style="box-sizing: content-box; z-index: -2;"
@@ -97,73 +101,77 @@ exports[`Header Component should match snapshot mobile without leanmode 1`] = `
         menu-link
       </div>
     </div>
-    <section
-      class="container-mock"
+    <div
+      class="w-100 bg-base"
     >
-      <div
-        class="w-100 mw9 flex justify-center pv6-l pv2-m"
-        style="pointer-events: none;"
+      <section
+        class="container-mock"
       >
         <div
-          class="flex w-100 justify-between-m items-center pv3"
-          style="pointer-events: auto;"
+          class="w-100 mw9 flex justify-center pv6-l pv2-m"
+          style="pointer-events: none;"
         >
           <div
-            class="topMenuLogo pv2 mr5"
+            class="flex w-100 justify-between-m items-center pv3"
+            style="pointer-events: auto;"
           >
             <div
-              class="link-mock"
+              class="topMenuLogo pv2 mr5"
             >
               <div
-                class="extension-point-mock"
-              >
-                logo
-              </div>
-            </div>
-          </div>
-          <div
-            class="dn db-ns flex-grow-1"
-          >
-            <div
-              class="topMenuSearchBar flex pa2-m flex-grow-1 justify-center"
-            >
-              <div
-                class="w-75"
+                class="link-mock"
               >
                 <div
                   class="extension-point-mock"
                 >
-                  search-bar
+                  logo
                 </div>
               </div>
             </div>
-          </div>
-          <div
-            class="topMenuIcons flex justify-end flex-grow-1 flex-grow-0-ns items-center order-1-s ml-auto-s order-2-ns"
-          >
             <div
-              class="flex"
+              class="dn db-ns flex-grow-1"
             >
               <div
-                class="extension-point-mock"
+                class="topMenuSearchBar flex pa2-m flex-grow-1 justify-center"
               >
-                login
-              </div>
-              <div
-                class="extension-point-mock"
-              >
-                minicart
+                <div
+                  class="w-75"
+                >
+                  <div
+                    class="extension-point-mock"
+                  >
+                    search-bar
+                  </div>
+                </div>
               </div>
             </div>
-          </div>
-          <div
-            class="extension-point-mock"
-          >
-            user-address
+            <div
+              class="topMenuIcons flex justify-end flex-grow-1 flex-grow-0-ns items-center order-1-s ml-auto-s order-2-ns"
+            >
+              <div
+                class="flex"
+              >
+                <div
+                  class="extension-point-mock"
+                >
+                  login
+                </div>
+                <div
+                  class="extension-point-mock"
+                >
+                  minicart
+                </div>
+              </div>
+            </div>
+            <div
+              class="extension-point-mock"
+            >
+              user-address
+            </div>
           </div>
         </div>
-      </div>
-    </section>
+      </section>
+    </div>
     <div
       class="no-ssr-mock"
     >
@@ -206,51 +214,55 @@ exports[`Header Component should match snapshot with leanmode 1`] = `
         menu-link
       </div>
     </div>
-    <section
-      class="container-mock"
+    <div
+      class="w-100 bg-base"
     >
-      <div
-        class="w-100 mw9 flex justify-center pv0"
-        style="pointer-events: none;"
+      <section
+        class="container-mock"
       >
         <div
-          class="flex w-100 justify-between-m items-center pv3"
-          style="pointer-events: auto;"
+          class="w-100 mw9 flex justify-center pv0"
+          style="pointer-events: none;"
         >
           <div
-            class="topMenuLogo pv2 mr5"
+            class="flex w-100 justify-between-m items-center pv3"
+            style="pointer-events: auto;"
           >
             <div
-              class="link-mock"
+              class="topMenuLogo pv2 mr5"
             >
               <div
-                class="extension-point-mock"
+                class="link-mock"
               >
-                logo
+                <div
+                  class="extension-point-mock"
+                >
+                  logo
+                </div>
               </div>
             </div>
-          </div>
-          <div
-            class="topMenuIcons flex justify-end flex-grow-1 flex-grow-0-ns items-center order-1-s ml-auto-s order-2-ns"
-          >
             <div
-              class="flex"
+              class="topMenuIcons flex justify-end flex-grow-1 flex-grow-0-ns items-center order-1-s ml-auto-s order-2-ns"
             >
               <div
-                class="extension-point-mock"
+                class="flex"
               >
-                login
+                <div
+                  class="extension-point-mock"
+                >
+                  login
+                </div>
               </div>
             </div>
-          </div>
-          <div
-            class="extension-point-mock"
-          >
-            user-address
+            <div
+              class="extension-point-mock"
+            >
+              user-address
+            </div>
           </div>
         </div>
-      </div>
-    </section>
+      </section>
+    </div>
     <div
       class="bb bw1 b--muted-4 relative"
       style="box-sizing: content-box; z-index: -2;"
@@ -283,73 +295,77 @@ exports[`Header Component should match snapshot without leanmode 1`] = `
         menu-link
       </div>
     </div>
-    <section
-      class="container-mock"
+    <div
+      class="w-100 bg-base"
     >
-      <div
-        class="w-100 mw9 flex justify-center pv6-l pv2-m"
-        style="pointer-events: none;"
+      <section
+        class="container-mock"
       >
         <div
-          class="flex w-100 justify-between-m items-center pv3"
-          style="pointer-events: auto;"
+          class="w-100 mw9 flex justify-center pv6-l pv2-m"
+          style="pointer-events: none;"
         >
           <div
-            class="topMenuLogo pv2 mr5"
+            class="flex w-100 justify-between-m items-center pv3"
+            style="pointer-events: auto;"
           >
             <div
-              class="link-mock"
+              class="topMenuLogo pv2 mr5"
             >
               <div
-                class="extension-point-mock"
-              >
-                logo
-              </div>
-            </div>
-          </div>
-          <div
-            class="dn db-ns flex-grow-1"
-          >
-            <div
-              class="topMenuSearchBar flex pa2-m flex-grow-1 justify-center"
-            >
-              <div
-                class="w-75"
+                class="link-mock"
               >
                 <div
                   class="extension-point-mock"
                 >
-                  search-bar
+                  logo
                 </div>
               </div>
             </div>
-          </div>
-          <div
-            class="topMenuIcons flex justify-end flex-grow-1 flex-grow-0-ns items-center order-1-s ml-auto-s order-2-ns"
-          >
             <div
-              class="flex"
+              class="dn db-ns flex-grow-1"
             >
               <div
-                class="extension-point-mock"
+                class="topMenuSearchBar flex pa2-m flex-grow-1 justify-center"
               >
-                login
-              </div>
-              <div
-                class="extension-point-mock"
-              >
-                minicart
+                <div
+                  class="w-75"
+                >
+                  <div
+                    class="extension-point-mock"
+                  >
+                    search-bar
+                  </div>
+                </div>
               </div>
             </div>
-          </div>
-          <div
-            class="extension-point-mock"
-          >
-            user-address
+            <div
+              class="topMenuIcons flex justify-end flex-grow-1 flex-grow-0-ns items-center order-1-s ml-auto-s order-2-ns"
+            >
+              <div
+                class="flex"
+              >
+                <div
+                  class="extension-point-mock"
+                >
+                  login
+                </div>
+                <div
+                  class="extension-point-mock"
+                >
+                  minicart
+                </div>
+              </div>
+            </div>
+            <div
+              class="extension-point-mock"
+            >
+              user-address
+            </div>
           </div>
         </div>
-      </div>
-    </section>
+      </section>
+    </div>
     <div
       class="no-ssr-mock"
     >

--- a/react/legacy/components/FixedContent.js
+++ b/react/legacy/components/FixedContent.js
@@ -38,82 +38,75 @@ const FixedContent = ({
   )
 
   return (
-    <Container
-      className={containerClasses}
-      style={{
-        transform: 'translateZ(0)', //Avoid shaking
-        zIndex: -1, // Allow popups to be on top of it
-      }}
-    >
-      <div
-        className={contentClasses}
+    <div className="w-100 bg-base">
+      <Container
+        className={containerClasses}
         style={{
-          /** Prevents the empty margins of this element from blocking the users clicks
-           * TODO: create a tachyons class for pointer events and remove this style
-           * @author lbebber */
-          pointerEvents: 'none',
+          transform: 'translateZ(0)', //Avoid shaking
         }}
       >
-        <div
-          className="flex w-100 justify-between-m items-center pv3"
-          style={{
-            pointerEvents: 'auto',
-          }}
-        >
-          {mobileSearchActive ? (
-            mobile &&
-            showSearchBar && (
-              <div className="flex justify-start pa2 relative w-100">
-                <SearchBar
-                  mobile={mobile}
-                  iconClasses={iconClasses}
-                  onCancel={() => toggleSearch(false)}
-                />
-              </div>
-            )
-          ) : (
-            <Fragment>
-              {!leanMode && mobile && (
-                <ExtensionPoint
-                  id="category-menu"
-                  mobileMode
-                  iconClasses={iconClasses}
-                />
-              )}
-
-              <Logo
-                logoUrl={logoUrl}
-                logoTitle={logoTitle}
-                linkUrl={linkUrl}
-                logoSize={logoSize}
-                mobile={mobile}
-              />
-
-              {!leanMode && !mobile && showSearchBar && (
-                <div className="dn db-ns flex-grow-1">
-                  <SearchBar mobile={mobile} />
+        <div className={contentClasses} style={{ pointerEvents: 'none' }}>
+          <div
+            className="flex w-100 justify-between-m items-center pv3"
+            style={{
+              pointerEvents: 'auto',
+            }}
+          >
+            {mobileSearchActive ? (
+              mobile &&
+              showSearchBar && (
+                <div className="flex justify-start pa2 relative w-100">
+                  <SearchBar
+                    mobile={mobile}
+                    iconClasses={iconClasses}
+                    onCancel={() => toggleSearch(false)}
+                  />
                 </div>
-              )}
+              )
+            ) : (
+              <Fragment>
+                {!leanMode && mobile && (
+                  <ExtensionPoint
+                    id="category-menu"
+                    mobileMode
+                    iconClasses={iconClasses}
+                  />
+                )}
 
-              <Actions
-                iconClasses={iconClasses}
-                labelClasses={labelClasses}
-                showSearchBar={showSearchBar}
-                showSearchIcon={showSearchBar}
-                leanMode={leanMode}
-                showLogin={showLogin}
-                onActiveSearch={() => toggleSearch(true)}
-                mobile={mobile}
-              />
+                <Logo
+                  logoUrl={logoUrl}
+                  logoTitle={logoTitle}
+                  linkUrl={linkUrl}
+                  logoSize={logoSize}
+                  mobile={mobile}
+                />
 
-              {!mobile && (
-                <ExtensionPoint id="user-address" variation="inline" />
-              )}
-            </Fragment>
-          )}
+                {!leanMode && !mobile && showSearchBar && (
+                  <div className="dn db-ns flex-grow-1">
+                    <SearchBar mobile={mobile} />
+                  </div>
+                )}
+
+                <Actions
+                  iconClasses={iconClasses}
+                  labelClasses={labelClasses}
+                  showSearchBar={showSearchBar}
+                  showSearchIcon={showSearchBar}
+                  leanMode={leanMode}
+                  showLogin={showLogin}
+                  onActiveSearch={() => toggleSearch(true)}
+                  mobile={mobile}
+                />
+
+                {!mobile && (
+                  <ExtensionPoint id="user-address" variation="inline" />
+                )}
+              </Fragment>
+            )}
+          </div>
         </div>
-      </div>
-    </Container>
+      </Container>
+    </div>
   )
 }
 


### PR DESCRIPTION
#### What is the purpose of this pull request?
<!--- Describe your changes in detail. -->

Fixes bug on legacy header regarding width of FixedContent.

Bug:
https://files.slack.com/files-pri/T02BCPD0X-FHWQC73JB/image.png
![image (2)](https://user-images.githubusercontent.com/5691711/55978481-45dc5d00-5c66-11e9-9015-91eab55df680.png)

Demo of fixed version:
https://lbebber4--storecomponents.myvtex.com/?disableUserLand

(the second bar only—the topmost telemarketing bar should be fixed on the Telemarketing app)

#### What problem is this solving?
<!--- What is the motivation and context for this change? -->

#### How should this be manually tested?

#### Screenshots or example usage

#### Types of changes
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
