### PR TITLE
Feature/z index

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- Prop `zIndex` to `header-row`.
 
 ## [2.20.2] - 2019-06-27
 

--- a/react/components/Row.tsx
+++ b/react/components/Row.tsx
@@ -8,6 +8,7 @@ import styles from './Row.css'
 
 interface Props {
   sticky?: boolean
+  zIndex?: number
   fullWidth?: boolean
   inverted?: boolean
 }
@@ -15,6 +16,7 @@ interface Props {
 const Row: FunctionComponent<Props & BlockClass> = ({
   children,
   sticky,
+  zIndex,
   fullWidth,
   inverted,
   blockClass,
@@ -26,7 +28,7 @@ const Row: FunctionComponent<Props & BlockClass> = ({
   )
 
   return (
-    <StickyRow sticky={sticky}>
+    <StickyRow sticky={sticky} zIndex={zIndex}>
       <div className={generateBlockClass(styles.headerRow, blockClass)}>
         <div
           className={classNames(

--- a/react/components/StickyRow.tsx
+++ b/react/components/StickyRow.tsx
@@ -4,19 +4,23 @@ import { RowContext } from './StickyRows'
 
 interface Props {
   sticky?: boolean
+  zIndex?: number
 }
 
-const StickyRow: FunctionComponent<Props> = ({ children, sticky }) => {
+const StickyRow: FunctionComponent<Props> = ({ children, sticky, zIndex }) => {
   const { offset, onResize } = useContext(RowContext)
 
   const stickyStyle: CSSProperties = {
     position: 'sticky',
     top: offset,
-    zIndex: 9,
+    zIndex,
   }
 
   return (
-    <div style={sticky ? stickyStyle : undefined}>
+    <div
+      style={sticky ? stickyStyle : undefined}
+      className={sticky && !zIndex ? 'z-999' : ''}
+    >
       {children}
 
       {sticky && (


### PR DESCRIPTION
#### What is the purpose of this pull request?
Allows changing the z-index of a sticky `header-row`.

https://lbebber--storecomponents.myvtex.com/
(see the "SELECTED ITEMS ON SALE!! CHECK IT OUT!!" row on the inspector—it should have a `z-index` of 8)

<!--- Describe your changes in detail. -->

#### What problem is this solving?
<!--- What is the motivation and context for this change? -->

#### How should this be manually tested?

#### Screenshots or example usage

#### Types of changes
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
