### PR TITLE
Fix/responsive hydration

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Fixed
+- Issue where the hydration would break under certain circumstances (namely, when the user agent would be that of a mobile device but the screen size would be considered a desktop).
 
 ## [2.21.0] - 2019-06-28
 ### Added

--- a/react/components/CustomHeader.tsx
+++ b/react/components/CustomHeader.tsx
@@ -1,5 +1,5 @@
 import React, { FunctionComponent } from 'react'
-import { ExtensionPoint, useRuntime } from 'vtex.render-runtime'
+import { ExtensionPoint, useRuntime, NoSSR } from 'vtex.render-runtime'
 import Media from 'react-media'
 
 const CustomHeader: FunctionComponent = () => {
@@ -7,22 +7,22 @@ const CustomHeader: FunctionComponent = () => {
     hints: { mobile },
   } = useRuntime()
 
-  if (!window || !window.matchMedia) {
-    return mobile ? (
-      <>
-        <ExtensionPoint id="header-layout.mobile" />
-        <ExtensionPoint id="unstable--header-layout.mobile" />
-      </>
-    ) : (
-      <>
-        <ExtensionPoint id="header-layout.desktop" />
-        <ExtensionPoint id="unstable--header-layout.desktop" />
-      </>
-    )
-  }
-
   return (
-    <React.Fragment>
+    <NoSSR
+      onSSR={
+        mobile ? (
+          <>
+            <ExtensionPoint id="header-layout.mobile" />
+            <ExtensionPoint id="unstable--header-layout.mobile" />
+          </>
+        ) : (
+          <>
+            <ExtensionPoint id="header-layout.desktop" />
+            <ExtensionPoint id="unstable--header-layout.desktop" />
+          </>
+        )
+      }
+    >
       <Media query="(max-width:40rem)">
         {matches =>
           matches ? (
@@ -38,7 +38,7 @@ const CustomHeader: FunctionComponent = () => {
           )
         }
       </Media>
-    </React.Fragment>
+    </NoSSR>
   )
 }
 

--- a/react/components/CustomHeader.tsx
+++ b/react/components/CustomHeader.tsx
@@ -2,6 +2,31 @@ import React, { FunctionComponent } from 'react'
 import { ExtensionPoint, useRuntime, NoSSR } from 'vtex.render-runtime'
 import Media from 'react-media'
 
+enum Device {
+  mobile = 'mobile',
+  desktop = 'desktop',
+}
+
+const CustomHeaderLayout = ({ device }: { device: Device }) => {
+  switch (device) {
+    case Device.mobile:
+      return (
+        <>
+          <ExtensionPoint id="header-layout.mobile" />
+          <ExtensionPoint id="unstable--header-layout.mobile" />
+        </>
+      )
+    case Device.desktop:
+    default:
+      return (
+        <>
+          <ExtensionPoint id="header-layout.desktop" />
+          <ExtensionPoint id="unstable--header-layout.desktop" />
+        </>
+      )
+  }
+}
+
 const CustomHeader: FunctionComponent = () => {
   const {
     hints: { mobile },
@@ -10,33 +35,15 @@ const CustomHeader: FunctionComponent = () => {
   return (
     <NoSSR
       onSSR={
-        mobile ? (
-          <>
-            <ExtensionPoint id="header-layout.mobile" />
-            <ExtensionPoint id="unstable--header-layout.mobile" />
-          </>
-        ) : (
-          <>
-            <ExtensionPoint id="header-layout.desktop" />
-            <ExtensionPoint id="unstable--header-layout.desktop" />
-          </>
-        )
+        <CustomHeaderLayout device={mobile ? Device.mobile : Device.desktop} />
       }
     >
       <Media query="(max-width:40rem)">
-        {matches =>
-          matches ? (
-            <>
-              <ExtensionPoint id="header-layout.mobile" />
-              <ExtensionPoint id="unstable--header-layout.mobile" />
-            </>
-          ) : (
-            <>
-              <ExtensionPoint id="header-layout.desktop" />
-              <ExtensionPoint id="unstable--header-layout.desktop" />
-            </>
-          )
-        }
+        {matches => (
+          <CustomHeaderLayout
+            device={matches ? Device.mobile : Device.desktop}
+          />
+        )}
       </Media>
     </NoSSR>
   )


### PR DESCRIPTION
#### What is the purpose of this pull request?
Fixes issue where the hydration would break under certain circumstances (namely, when the user agent would be that of a mobile device but the screen size would be considered a desktop).

Before:
<img width="1055" alt="Screen Shot 2019-07-03 at 14 21 04" src="https://user-images.githubusercontent.com/5691711/60612859-10946680-9da0-11e9-9dee-3c76fa546d54.png">

After:
<img width="1039" alt="Screen Shot 2019-07-03 at 14 21 10" src="https://user-images.githubusercontent.com/5691711/60612877-1e49ec00-9da0-11e9-92b5-03074d7f3141.png">

Test on https://lbebber2--ecowaterqa.myvtex.com/, on responsive mode, with about the screen size shown on the screenshots above.



#### What problem is this solving?
<!--- What is the motivation and context for this change? -->

#### How should this be manually tested?

#### Screenshots or example usage

#### Types of changes
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
