### PR TITLE
Allow new interfaces from the new minicart

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Added
+- New minicart-base-content interface to the allowed list in both header and header-row.
 
 ## [2.22.1] - 2019-11-01
 ### Fixed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,7 +7,7 @@ and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.
 
 ## [Unreleased]
 ### Added
-- New minicart-base-content interface to the allowed list in both header and header-row.
+- New `minicart-base-content` interface to the allowed list in both header and header-row.
 
 ## [2.22.1] - 2019-11-01
 ### Fixed

--- a/manifest.json
+++ b/manifest.json
@@ -13,16 +13,14 @@
   },
   "mustUpdateAt": "2019-04-02",
   "categories": [],
-  "registries": [
-    "smartcheckout"
-  ],
+  "registries": ["smartcheckout"],
   "scripts": {
     "postreleasy": "vtex publish --verbose"
   },
   "dependencies": {
     "vtex.styleguide": "9.x",
     "vtex.telemarketing": "2.x",
-    "vtex.minicart": "2.x",
+    "vtex.minicart": "3.x",
     "vtex.login": "2.x",
     "vtex.menu": "2.x",
     "vtex.category-menu": "2.x",

--- a/manifest.json
+++ b/manifest.json
@@ -20,7 +20,7 @@
   "dependencies": {
     "vtex.styleguide": "9.x",
     "vtex.telemarketing": "2.x",
-    "vtex.minicart": "3.x",
+    "vtex.minicart": "2.x",
     "vtex.login": "2.x",
     "vtex.menu": "2.x",
     "vtex.category-menu": "2.x",

--- a/store/interfaces.json
+++ b/store/interfaces.json
@@ -2,6 +2,7 @@
   "header": {
     "allowed": [
       "minicart",
+      "minicart-base-content",
       "login",
       "category-menu",
       "search-bar",
@@ -26,10 +27,7 @@
   },
   "header.full": {},
   "header-layout": {
-    "allowed": [
-      "header-row",
-      "header-border"
-    ],
+    "allowed": ["header-row", "header-border"],
     "component": "Layout",
     "composition": "children"
   },
@@ -46,6 +44,7 @@
       "notification",
       "logo",
       "minicart",
+      "minicart-base-content",
       "login",
       "search-bar",
       "locale-switcher",
@@ -69,10 +68,7 @@
   "theme": {},
 
   "unstable--header-layout": {
-    "allowed": [
-      "unstable--header-row",
-      "unstable--header-border"
-    ],
+    "allowed": ["unstable--header-row", "unstable--header-border"],
     "component": "Layout",
     "composition": "children"
   },


### PR DESCRIPTION
#### What is the purpose of this pull request?

Add the new `minicart-base-content` interface to the `allowed` list in both `header` and `header-row`.

#### What problem is this solving?

Allow users to use the new minicart.

#### How should this be manually tested?

https://minicart--storecomponents.myvtex.com/

#### Types of changes
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [x] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.

#### Notes

**THIS SHOULD ONLY BE RELEASED AFTER https://github.com/vtex-apps/minicart/pull/184**