### PR TITLE
Update default header.full blocks implementation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ The format is based on [Keep a Changelog](http://keepachangelog.com/en/1.0.0/)
 and this project adheres to [Semantic Versioning](http://semver.org/spec/v2.0.0.html).
 
 ## [Unreleased]
+### Changed
+- Default blocks implementation for `header.full`.
 
 ## [2.22.1] - 2019-11-01
 ### Fixed

--- a/store/blocks.json
+++ b/store/blocks.json
@@ -15,7 +15,13 @@
     }
   },
   "header-row#desktop-2": {
-    "children": ["logo", "header-spacer", "search-bar", "login", "minicart"],
+    "children": [
+      "logo#header",
+      "header-spacer",
+      "search-bar",
+      "login",
+      "minicart"
+    ],
     "props": {
       "sticky": true
     }
@@ -24,22 +30,37 @@
     "children": ["category-menu"]
   },
   "header-layout.mobile": {
-    "children": [
-      "header-row#mobile-1",
-      "header-row#mobile-2",
-      "header-row#mobile-3"
-    ]
+    "children": ["header-row#mobile-2"]
   },
   "header-row#mobile-1": {
     "children": ["telemarketing"],
     "props": {
-      "fullWidth": true
+      "fullWidth": true,
+      "sticky": true
     }
   },
   "header-row#mobile-2": {
-    "children": ["logo", "search-bar", "locale-switcher", "login", "minicart"]
+    "children": [
+      "logo#header",
+      "header-spacer",
+      "login#header-mobile",
+      "minicart"
+    ],
+    "props": {
+      "sticky": true
+    }
   },
-  "header-row#mobile-3": {
-    "children": ["category-menu"]
+  "login#header-mobile": {
+    "props": {
+      "showIconProfile": true
+    }
+  },
+  "logo#header": {
+    "props": {
+      "width": 132,
+      "height": 32,
+      "mobileWidth": 90,
+      "mobileHeight": 32
+    }
   }
 }

--- a/store/blocks.json
+++ b/store/blocks.json
@@ -1,53 +1,27 @@
 {
   "header": {
-    "blocks": [
-      "telemarketing",
-      "logo"
-    ]
+    "blocks": ["telemarketing", "logo"]
   },
   "header.full": {
-    "blocks": [
-      "telemarketing",
-      "logo",
-      "minicart",
-      "login",
-      "category-menu",
-      "search-bar",
-      "locale-switcher"
-    ]
+    "blocks": ["header-layout.desktop", "header-layout.mobile"]
   },
   "header-layout.desktop": {
-    "children": [
-      "header-row#desktop-1",
-      "header-row#desktop-2",
-      "header-row#desktop-3"
-    ]
+    "children": ["header-row#desktop-1", "header-row#desktop-2"]
   },
   "header-row#desktop-1": {
-    "children": [
-      "telemarketing"
-    ],
+    "children": ["telemarketing"],
     "props": {
       "fullWidth": true
     }
   },
   "header-row#desktop-2": {
-    "children": [
-      "header-spacer",
-      "search-bar",
-      "locale-switcher",
-      "header-spacer",
-      "login",
-      "minicart"
-    ],
+    "children": ["logo", "header-spacer", "search-bar", "login", "minicart"],
     "props": {
       "sticky": true
     }
   },
   "header-row#desktop-3": {
-    "children": [
-      "category-menu"
-    ]
+    "children": ["category-menu"]
   },
   "header-layout.mobile": {
     "children": [
@@ -57,25 +31,15 @@
     ]
   },
   "header-row#mobile-1": {
-    "children": [
-      "telemarketing"
-    ],
+    "children": ["telemarketing"],
     "props": {
       "fullWidth": true
     }
   },
   "header-row#mobile-2": {
-    "children": [
-      "logo",
-      "search-bar",
-      "locale-switcher",
-      "login",
-      "minicart"
-    ]
+    "children": ["logo", "search-bar", "locale-switcher", "login", "minicart"]
   },
   "header-row#mobile-3": {
-    "children": [
-      "category-menu"
-    ]
+    "children": ["category-menu"]
   }
 }


### PR DESCRIPTION
#### What is the purpose of this pull request?

Update the default blocks implementation for `header.full`.

#### What problem is this solving?

The current default implementation does not use `header-layout` interfaces and also uses `category-menu`s. This new one is simpler and uses our new components.

#### How should this be manually tested?

This is a workspace using the default header (no header defined in a `store-theme`):
https://defaultblocks--storecomponents.myvtex.com/

#### Types of changes
- [ ] Bug fix (a non-breaking change which fixes an issue)
- [ ] New feature (a non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Requires change to documentation, which has been updated accordingly.
- [x] Technical improvements.
